### PR TITLE
fix: Resolve build error by removing out-of-scope inputRef call

### DIFF
--- a/src/components/ModernImagen.tsx
+++ b/src/components/ModernImagen.tsx
@@ -961,7 +961,7 @@ export default function ModernImagen() {
     if (!presetName.trim()) {
       showToast('Preset name cannot be empty.', 'error');
       // Keep modal open, let user correct
-      inputRef.current?.focus(); // Refocus input in modal - need to ensure inputRef is accessible or pass it
+      // inputRef.current?.focus(); // This line caused a build error as inputRef is not in this scope. Modal input focuses on open anyway.
       return;
     }
     if (!prompt.trim()) { // Should not happen if initiateSavePreset was called, but good check


### PR DESCRIPTION
This commit fixes a TypeScript build error (`Type error: Cannot find name 'inputRef'`) that occurred in the `handleSavePresetConfirm` function within `ModernImagen.tsx`.

The error was caused by an attempt to focus an `inputRef` that is local to the `SavePresetModal` component and not accessible from the `handleSavePresetConfirm` function in the parent component.

The problematic line `inputRef.current?.focus()` has been removed. The `SavePresetModal` already handles focusing its input field upon opening. If an empty preset name is submitted, the modal remains open, and the user can manually refocus the input if needed.

This change ensures the application builds successfully.