### PR TITLE
feat: Display batch results on main page and adjust layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,13 @@ body {
   color: var(--foreground);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
+
+/* Custom utility to hide scrollbars */
+.hide-native-scrollbar {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.hide-native-scrollbar::-webkit-scrollbar {
+  display: none;  /* Safari and Chrome */
+}

--- a/src/components/ModernImagen.tsx
+++ b/src/components/ModernImagen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from 'react';
-import { Camera, Download, Settings, History, Sparkles, Trash2, Copy, Moon, Sun, Loader2, Zap, ImageIcon, Palette, Share2 } from 'lucide-react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { Camera, Download, Settings, History, Sparkles, Trash2, Copy, Moon, Sun, Loader2, Zap, ImageIcon, Palette, Share2, Lightbulb, Image as ImageIconLucide, Film, Brush, Square as SquareIcon, Mic2, Wand2, Check, ChevronLeft, ChevronRight } from 'lucide-react';
 
 // Types
 interface GeneratedImage {
@@ -220,6 +220,150 @@ const ImageModal = ({ imageUrl, prompt, onClose, onDownload, theme }: {
   );
 };
 
+const SavePresetModal = ({
+  isOpen,
+  onClose,
+  onSave,
+  presetName,
+  setPresetName,
+  theme
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: () => void;
+  presetName: string;
+  setPresetName: (name: string) => void;
+  theme: string;
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const saveButtonRef = useRef<HTMLButtonElement>(null); // For focusing on save button initially
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      previouslyFocusedElement.current = document.activeElement as HTMLElement;
+      // Focus the input field when the modal opens
+      inputRef.current?.focus();
+    } else {
+      previouslyFocusedElement.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+      if (e.key === 'Enter' && presetName.trim()) {
+        onSave();
+      }
+      // Basic tab trapping
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = Array.from(
+          modalRef.current.querySelectorAll<HTMLElement>(
+            'input, button, [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter(el => el.offsetParent !== null); // Filter out hidden elements
+
+        if (focusableElements.length === 0) return;
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) { // Shift + Tab
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else { // Tab
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose, onSave, presetName]);
+
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={modalRef}
+      className="fixed inset-0 bg-black/75 z-[80] flex items-center justify-center p-4" // Ensure high z-index
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-preset-modal-title"
+    >
+      <div
+        className={`relative w-full max-w-md rounded-xl p-6 shadow-xl ${
+          theme === 'dark' ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="save-preset-modal-title" className={`text-xl font-semibold mb-4 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
+          Save Preset
+        </h2>
+
+        <div className="space-y-2 mb-6">
+          <label htmlFor="presetNameInput" className={`block text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
+            Preset Name
+          </label>
+          <input
+            id="presetNameInput"
+            ref={inputRef}
+            type="text"
+            value={presetName}
+            onChange={(e) => setPresetName(e.target.value)}
+            placeholder="e.g., My Awesome Style"
+            className={`w-full rounded-lg p-3 border focus:ring-2 focus:border-blue-500 transition-all duration-200 min-h-[44px] ${
+              theme === 'dark'
+                ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400 focus:ring-blue-500'
+                : 'bg-gray-50 border-gray-300 text-gray-900 placeholder-gray-400 focus:ring-blue-500'
+            }`}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-3">
+          <button
+            onClick={onClose}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors min-h-[40px] ${
+              theme === 'dark'
+                ? 'bg-gray-600 hover:bg-gray-500 text-white focus:ring-gray-400'
+                : 'bg-gray-200 hover:bg-gray-300 text-gray-700 focus:ring-gray-400'
+            } focus:ring-2 focus:ring-offset-2 ${theme === 'dark' ? 'focus:ring-offset-gray-800' : 'focus:ring-offset-white'}`}
+          >
+            Cancel
+          </button>
+          <button
+            ref={saveButtonRef}
+            onClick={onSave}
+            disabled={!presetName.trim()}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors min-h-[40px] flex items-center justify-center shadow-sm ${
+              !presetName.trim()
+                ? (theme === 'dark' ? 'bg-gray-500 text-gray-400 cursor-not-allowed' : 'bg-gray-300 text-gray-500 cursor-not-allowed')
+                : (theme === 'dark'
+                    ? 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500'
+                    : 'bg-blue-500 hover:bg-blue-600 text-white focus:ring-blue-400')
+            } focus:ring-2 focus:ring-offset-2 ${theme === 'dark' ? 'focus:ring-offset-gray-800' : 'focus:ring-offset-white'}`}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const LoadingSpinner = () => (
   <div className="flex items-center justify-center p-8" role="status" aria-live="polite">
     <Loader2 className="w-8 h-8 animate-spin text-blue-500" aria-hidden="true" />
@@ -227,17 +371,48 @@ const LoadingSpinner = () => (
   </div>
 );
 
-const ImageCard = ({ image, onDelete, onCopy, onDownload, onEnlarge, theme }: { // Added theme prop
+const ImageCard = ({
+  image,
+  onDelete,
+  onCopy,
+  onDownload,
+  onEnlarge,
+  theme,
+  isSelected,
+  onSelect
+}: {
   image: GeneratedImage;
   onDelete: (id: string) => void;
   onCopy: (image: GeneratedImage) => void;
   onDownload: (url: string) => void;
   onEnlarge: (image: GeneratedImage) => void;
-  theme: string; // Added theme prop
+  theme: string;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
 }) => (
   <div className={`group relative rounded-lg overflow-hidden border transition-all duration-300 focus-within:ring-2 focus-within:ring-blue-500 ${
     theme === 'dark' ? 'bg-gray-800/70 border-gray-700 hover:border-gray-600' : 'bg-white border-gray-200 hover:border-gray-300 shadow-sm'
-  }`}>
+  } ${isSelected ? (theme === 'dark' ? 'ring-2 ring-blue-500 border-blue-500' : 'ring-2 ring-blue-500 border-blue-500') : ''}`}>
+    <div
+      className="absolute top-2 right-2 z-10 p-1.5 rounded-full cursor-pointer transition-colors focus:ring-2 focus:ring-offset-1"
+      onClick={(e) => {
+        e.stopPropagation(); // Prevent onEnlarge when clicking checkbox
+        onSelect(image.id);
+      }}
+      role="checkbox"
+      aria-checked={isSelected}
+      tabIndex={0} // Make it focusable
+      onKeyDown={(e) => { if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); onSelect(image.id); }}}
+      aria-label={`Select image for comparison: ${image.prompt}`}
+    >
+      <div className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
+        isSelected
+          ? (theme === 'dark' ? 'bg-blue-600 border-blue-500' : 'bg-blue-600 border-blue-500')
+          : (theme === 'dark' ? 'border-gray-400 hover:border-gray-300' : 'border-gray-500 hover:border-gray-400')
+      }`}>
+        {isSelected && <Check className={`w-3 h-3 ${theme === 'dark' ? 'text-white' : 'text-white'}`} />}
+      </div>
+    </div>
     <div className="aspect-square relative overflow-hidden cursor-pointer" onClick={() => onEnlarge(image)} role="button" aria-label={`View details for image: ${image.prompt}`}>
       <img 
         src={image.url} 
@@ -331,6 +506,139 @@ const PresetCard = ({ preset, onLoad, onDelete, theme }: { // Added theme prop
   </div>
 );
 
+const ComparisonModal = ({
+  imagesToCompare,
+  allImages,
+  theme,
+  onClose,
+  onDownload
+}: {
+  imagesToCompare: string[];
+  allImages: GeneratedImage[];
+  theme: string;
+  onClose: () => void;
+  onDownload: (url: string) => void;
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  const selectedImagesData = allImages.filter(img => imagesToCompare.includes(img.id));
+
+  useEffect(() => {
+    previouslyFocusedElement.current = document.activeElement as HTMLElement;
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+      // Basic tab trapping
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length === 0) return;
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+        if (e.shiftKey) { // Shift + Tab
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else { // Tab
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedElement.current?.focus();
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={modalRef}
+      className="fixed inset-0 bg-black/85 z-[70] flex items-center justify-center p-4 overflow-y-auto" // Higher z-index than image modal
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="comparison-modal-title"
+    >
+      <div
+        className={`relative w-full max-w-6xl max-h-[90vh] flex flex-col rounded-xl p-4 sm:p-6 ${
+          theme === 'dark' ? 'bg-gray-800' : 'bg-white'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 id="comparison-modal-title" className={`text-xl sm:text-2xl font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
+            Compare Images ({selectedImagesData.length})
+          </h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className={`p-2 rounded-full transition-colors ${
+              theme === 'dark'
+                ? 'bg-gray-700 hover:bg-gray-600 text-gray-300 hover:text-white focus:ring-gray-500'
+                : 'bg-gray-200 hover:bg-gray-300 text-gray-700 hover:text-gray-900 focus:ring-gray-400'
+            } focus:ring-2`}
+            aria-label="Close comparison view"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="flex-grow overflow-y-auto pr-2"> {/* Added pr-2 for scrollbar spacing */}
+          <div className={`grid grid-cols-1 md:grid-cols-${selectedImagesData.length > 1 ? selectedImagesData.length : 2} gap-4 sm:gap-6`}>
+            {selectedImagesData.map((image) => (
+              <div key={image.id} className={`rounded-lg border p-3 flex flex-col ${theme === 'dark' ? 'bg-gray-700/70 border-gray-600' : 'bg-gray-50 border-gray-200'}`}>
+                <img
+                  src={image.url}
+                  alt={image.prompt}
+                  className="w-full aspect-square object-cover rounded-md mb-3"
+                />
+                <div className="space-y-1.5 text-xs overflow-hidden">
+                  <p className={`${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`} title={image.prompt}>
+                    <strong className={`${theme === 'dark' ? 'text-white' : 'text-black'}`}>Prompt:</strong> <span className="block max-h-10 overflow-y-auto text-ellipsis">{image.prompt}</span>
+                  </p>
+                  <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                    <strong className={`${theme === 'dark' ? 'text-white' : 'text-black'}`}>Model:</strong> {image.model}
+                  </p>
+                  <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                    <strong className={`${theme === 'dark' ? 'text-white' : 'text-black'}`}>Size:</strong> {image.width}x{image.height}
+                  </p>
+                  {image.seed && (
+                    <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                      <strong className={`${theme === 'dark' ? 'text-white' : 'text-black'}`}>Seed:</strong> {image.seed}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => onDownload(image.url)}
+                  className={`mt-3 w-full p-2 rounded-md text-xs font-medium transition-colors flex items-center justify-center ${
+                    theme === 'dark'
+                      ? 'bg-blue-700 hover:bg-blue-600 text-white focus:ring-blue-500'
+                      : 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-400'
+                  } focus:ring-2 focus:ring-offset-1 ${theme === 'dark' ? 'focus:ring-offset-gray-700' : 'focus:ring-offset-gray-50' }`}
+                >
+                  <Download className="w-3 h-3 mr-1.5" /> Download
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+
 // Main Component
 export default function ModernImagen() {
   // State variables for prompt, dimensions, model, and seed
@@ -339,6 +647,7 @@ export default function ModernImagen() {
   const [height, setHeight] = useState(1024);
   const [model, setModel] = useState('flux');
   const [seed, setSeed] = useState('');
+  const [batchSize, setBatchSize] = useState(1); // Added batchSize state
   const [isGenerating, setIsGenerating] = useState(false);
   const [currentImage, setCurrentImage] = useState<string>('https://placehold.co/1024x1024/111827/4f4f52?text=Your+Image+Will+Appear+Here');
   const [activeTab, setActiveTab] = useState<'generate' | 'history' | 'presets'>('generate');
@@ -346,8 +655,22 @@ export default function ModernImagen() {
   const [isMounted, setIsMounted] = useState(false);
   const [enlargedImage, setEnlargedImage] = useState<{ url: string; prompt: string } | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
   const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
+  const stylePresetsContainerRef = useRef<HTMLDivElement>(null);
   
+  const [canScrollStylePresetsLeft, setCanScrollStylePresetsLeft] = useState(false);
+  const [canScrollStylePresetsRight, setCanScrollStylePresetsRight] = useState(false);
+
+  const [selectedForComparison, setSelectedForComparison] = useState<string[]>([]);
+  const [showComparisonView, setShowComparisonView] = useState(false);
+
+  const [showSavePresetModal, setShowSavePresetModal] = useState(false);
+  const [presetName, setPresetName] = useState('');
+
+  const [currentBatchResults, setCurrentBatchResults] = useState<GeneratedImage[]>([]);
+
   const initialDarkPlaceholder = 'https://placehold.co/1024x1024/111827/4f4f52?text=Your+Image+Will+Appear+Here';
   const initialLightPlaceholder = 'https://placehold.co/1024x1024/f3f4f6/1f2937?text=Your+Image+Will+Appear+Here'; // bg-gray-200, text-gray-800
 
@@ -356,6 +679,71 @@ export default function ModernImagen() {
   const [presets, setPresets] = useLocalStorage<Preset[]>('image-presets', []);
   const { theme, toggleTheme } = useTheme();
 
+  // Define Style Presets - MOVED EARLIER & MEMOIZED
+  const stylePresets = useMemo(() => [
+    { id: 'photo', name: 'Photorealistic', promptSuffix: ', photorealistic, 8k, sharp focus', icon: ImageIconLucide },
+    { id: 'film', name: 'Cinematic', promptSuffix: ', cinematic lighting, film grain, dramatic', icon: Film },
+    { id: 'brush', name: 'Painting', promptSuffix: ', oil painting, impressionistic, textured brush strokes', icon: Brush },
+    { id: 'vector', name: 'Vector Art', promptSuffix: ', vector illustration, flat colors, clean lines', icon: SquareIcon },
+    { id: 'pixel', name: 'Pixel Art', promptSuffix: ', pixel art, 16-bit, retro game style', icon: Wand2 },
+    { id: 'fantasy', name: 'Fantasy', promptSuffix: ', fantasy art, epic, detailed illustration', icon: Mic2 },
+  ], []); // Empty dependency array means it's created once
+
+  useEffect(() => {
+    if (batchSize < 1) setBatchSize(1);
+    if (batchSize > 5) setBatchSize(5); // Max 5 images per batch
+  }, [batchSize]);
+
+  const checkStylePresetScrollability = () => {
+    const container = stylePresetsContainerRef.current;
+    if (container) {
+      const { scrollLeft, scrollWidth, clientWidth } = container;
+      setCanScrollStylePresetsLeft(scrollLeft > 0);
+      setCanScrollStylePresetsRight(scrollLeft < scrollWidth - clientWidth -1); // -1 for precision issues
+    }
+  };
+
+  useEffect(() => {
+    const container = stylePresetsContainerRef.current;
+    checkStylePresetScrollability(); // Initial check
+
+    container?.addEventListener('scroll', checkStylePresetScrollability);
+    window.addEventListener('resize', checkStylePresetScrollability); // Recalculate on resize
+
+    // Also check after presets might have rendered/changed
+    const timeoutId = setTimeout(checkStylePresetScrollability, 100);
+
+
+    return () => {
+      container?.removeEventListener('scroll', checkStylePresetScrollability);
+      window.removeEventListener('resize', checkStylePresetScrollability);
+      clearTimeout(timeoutId);
+    };
+  }, [stylePresets]); // Re-check if stylePresets array changes, though it's static here
+
+  const scrollStylePresets = (direction: 'left' | 'right') => {
+    const container = stylePresetsContainerRef.current;
+    if (container) {
+      const scrollAmount = container.clientWidth / 2; // Scroll by half the visible width
+      container.scrollBy({
+        left: direction === 'left' ? -scrollAmount : scrollAmount,
+        behavior: 'smooth'
+      });
+    }
+  };
+
+  const predefinedSuggestions = [
+    "cinematic lighting", "hyperrealistic", "fantasy art", "sci-fi concept",
+    "impressionist painting", "close-up portrait", "wide angle landscape",
+    "vector art", "pixel art", "steampunk", "cyberpunk", "vaporwave",
+    "detailed illustration", "oil painting", "watercolor", "charcoal sketch",
+    "low poly", "isometric view", "depth of field", "golden hour", "blue hour",
+    "dramatic lighting", "volumetric lighting", "studio lighting", "softbox lighting",
+    "8k resolution", "highly detailed", "intricate details", "sharp focus",
+    "vibrant colors", "monochromatic", "sepia tone", "black and white"
+  ];
+
+  // useEffect for theme dependent placeholder (Keep this early if it doesn't depend on later declarations)
   useEffect(() => {
     setIsMounted(true);
     // Check if currentImage is the default dark placeholder and theme is light
@@ -377,6 +765,58 @@ export default function ModernImagen() {
     }
   }, [activeTab, prompt, isMounted]);
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      // Check if the click is outside the suggestions dropdown and the suggestion button
+      if (suggestionsRef.current && !suggestionsRef.current.contains(event.target as Node) &&
+          !(event.target as HTMLElement).closest('#suggestion-button')) {
+        setShowSuggestions(false);
+      }
+    };
+
+    if (showSuggestions) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showSuggestions]);
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setPrompt(prev => {
+      const newPrompt = prev.trim();
+      // Add a comma if the prompt isn't empty and doesn't end with a comma
+      if (newPrompt && !newPrompt.endsWith(',')) {
+        return `${newPrompt}, ${suggestion}`;
+      }
+      // If prompt is empty or ends with a comma, just append the suggestion
+      return `${newPrompt} ${suggestion}`;
+    });
+    setShowSuggestions(false); // Hide suggestions after selection
+    promptTextareaRef.current?.focus(); // Focus back on the prompt
+  };
+
+  const handleStylePresetClick = (suffix: string) => {
+    setPrompt(prev => {
+      const newPrompt = prev.trim();
+      if (newPrompt && !newPrompt.endsWith(',')) {
+        return `${newPrompt}, ${suffix.startsWith(',') ? suffix.substring(1).trim() : suffix.trim()}`;
+      }
+      return `${newPrompt} ${suffix.startsWith(',') ? suffix.substring(1).trim() : suffix.trim()}`;
+    });
+    showToast('Style applied to prompt!', 'success');
+    promptTextareaRef.current?.focus();
+  };
+
+  const toggleSelectForComparison = (id: string) => {
+    setSelectedForComparison(prev =>
+      prev.includes(id) ? prev.filter(imageId => imageId !== id) : [...prev, id]
+    );
+  };
+
   // Ref for handling image download
   const downloadRef = useRef<HTMLAnchorElement>(null);
 
@@ -388,72 +828,120 @@ export default function ModernImagen() {
 
   // Function to generate an image
   const generateImage = async (e?: React.FormEvent) => {
-    if (e) e.preventDefault(); // Prevent default form submission
+    if (e) e.preventDefault();
 
-    // Validate prompt input
     if (!prompt.trim()) {
       showToast('Please enter a prompt to generate an image.', 'error');
       return;
     }
 
-    setIsGenerating(true); // Set generating state to true
+    setIsGenerating(true);
+    setCurrentBatchResults([]); // Clear previous batch results
+    const currentBatchSize = Math.max(1, Math.min(batchSize, 5));
+    let generatedCount = 0;
+    const newImagesBatch: GeneratedImage[] = [];
 
-    try {
-      // Encode prompt and construct URL parameters
-      const encodedPrompt = encodeURIComponent(prompt.trim());
-      const params = new URLSearchParams({
-        width: width.toString(),
-        height: height.toString(),
-        model: model,
-        nologo: 'true' // Added nologo parameter
-      });
-
-      if (seed && seed.trim()) {
-        params.append('seed', seed.trim());
-      }
-
-      const finalURL = `https://image.pollinations.ai/prompt/${encodedPrompt}?${params.toString()}`;
-      console.log('Generating image with URL:', finalURL);
-      
-      // Load image to check for errors before setting it
-      const testImage = new Image();
-      testImage.crossOrigin = 'anonymous'; // Required for cross-origin images
-
-      await new Promise((resolve, reject) => {
-        testImage.onload = () => {
-          console.log('Image loaded successfully');
-          resolve(testImage);
-        };
-        testImage.onerror = (error) => {
-          console.error('Image failed to load:', error);
-          reject(error);
-        };
-        testImage.src = finalURL;
-      });
-      
-      // Create a new GeneratedImage object and add to history
-      const newImage: GeneratedImage = {
-        id: Date.now().toString(),
-        url: finalURL,
-        prompt: prompt.trim(),
-        model,
-        width,
-        height,
-        seed: seed?.trim() || undefined,
-        timestamp: Date.now()
-      };
-
-      setCurrentImage(finalURL); // Set the current displayed image
-      setImages(prev => [newImage, ...prev.slice(0, 49)]); // Add to history, keeping max 50 images
-      showToast('Image generated successfully!', 'success');
-    } catch (error) {
-      console.error('Generation error:', error);
-      showToast('Failed to generate image. Please try again.', 'error');
-      // Set a specific error placeholder image
-      setCurrentImage('https://placehold.co/1024x1024/111827/ff4d4d?text=Error+Loading+Image');
-    } finally {
-      setIsGenerating(false); // Reset generating state
+    if (currentBatchSize > 1) {
+      showToast(`Starting batch generation for ${currentBatchSize} images...`, 'success');
+      setCurrentImage(theme === 'dark' ? initialDarkPlaceholder : initialLightPlaceholder); // Reset main preview for batch
+    } else {
+      // For single image, also ensure batch results are clear
+      // setCurrentBatchResults([]); // Already cleared above
     }
+
+
+    for (let i = 0; i < currentBatchSize; i++) {
+      try {
+        const currentSeed = (i === 0 && seed.trim() && currentBatchSize === 1) ? seed.trim() : Math.floor(Math.random() * 1000000).toString();
+
+        if (currentBatchSize > 1) {
+          showToast(`Generating image ${i + 1} of ${currentBatchSize}... (Seed: ${currentSeed})`, 'success');
+        }
+
+        const encodedPrompt = encodeURIComponent(prompt.trim());
+        const params = new URLSearchParams({
+          width: width.toString(),
+          height: height.toString(),
+          model: model,
+          nologo: 'true',
+          seed: currentSeed,
+        });
+
+        const finalURL = `https://image.pollinations.ai/prompt/${encodedPrompt}?${params.toString()}`;
+        console.log(`Generating image ${i + 1}/${currentBatchSize} with URL:`, finalURL);
+
+        const testImage = new Image();
+        testImage.crossOrigin = 'anonymous';
+
+        await new Promise<void>((resolve, reject) => { // Explicitly type Promise for clarity
+          testImage.onload = () => {
+            console.log(`Image ${i + 1} loaded successfully`);
+            resolve();
+          };
+          testImage.onerror = (error) => {
+            console.error(`Image ${i + 1} failed to load:`, error);
+            reject(error);
+          };
+          testImage.src = finalURL;
+        });
+
+        const newImage: GeneratedImage = {
+          id: `${Date.now()}-${i}`,
+          url: finalURL,
+          prompt: prompt.trim(),
+          model,
+          width,
+          height,
+          seed: currentSeed,
+          timestamp: Date.now(),
+        };
+        newImagesBatch.push(newImage);
+
+        if (currentBatchSize === 1) {
+          setCurrentImage(finalURL); // Update main preview for single image
+        } else if (i === 0) { // For batch, set main preview to the first image initially
+          setCurrentImage(finalURL);
+        }
+        generatedCount++;
+
+      } catch (error) {
+        console.error(`Error generating image ${i + 1} in batch:`, error);
+        showToast(`Failed to generate image ${i + 1} of ${currentBatchSize}.`, 'error');
+        if (currentBatchSize === 1) {
+             setCurrentImage(theme === 'dark' ? initialDarkPlaceholder : initialLightPlaceholder);
+        }
+        // Continue to next image in batch
+      }
+    }
+
+    if (newImagesBatch.length > 0) {
+      setImages(prev => [...newImagesBatch, ...prev.slice(0, 50 - newImagesBatch.length)]);
+      if (currentBatchSize > 1) {
+        setCurrentBatchResults(newImagesBatch);
+        // If main preview was set to first batch image, keep it. Or set a specific placeholder.
+        // For now, currentImage shows the first successful batch image, or last if only one from batch.
+        // If batch completely failed, currentImage would be placeholder.
+        if (newImagesBatch.length > 0) setCurrentImage(newImagesBatch[0].url);
+      }
+    }
+
+
+    if (currentBatchSize > 1) {
+        if (generatedCount === currentBatchSize) {
+            showToast(`Batch complete! ${generatedCount} images generated.`, 'success');
+        } else if (generatedCount > 0) {
+            showToast(`Batch partially complete. ${generatedCount} of ${currentBatchSize} images generated.`, 'success');
+        } else {
+             showToast(`Batch failed. No images were generated.`, 'error');
+             setCurrentImage(theme === 'dark' ? initialDarkPlaceholder : initialLightPlaceholder);
+        }
+    } else if (generatedCount === 1) { // Single image success
+        showToast('Image generated successfully!', 'success');
+    } else if (currentBatchSize === 1 && generatedCount === 0) { // Single image fail
+        // Toast already shown in catch, currentImage already reset in catch
+    }
+
+    setIsGenerating(false);
   };
 
   // Function to download the current image
@@ -478,30 +966,45 @@ export default function ModernImagen() {
     }
   };
 
-  // Function to save current settings as a preset
-  const savePreset = () => {
+  // Function to initiate saving current settings as a preset
+  const initiateSavePreset = () => {
     if (!prompt.trim()) {
       showToast('Please enter a prompt before saving preset.', 'error');
       return;
     }
-
-    if (isMounted) {
-      const name = window.prompt('Enter preset name:'); // Prompt user for preset name
-      if (!name) return; // If no name entered, do nothing
-
-      const newPreset: Preset = {
-        id: Date.now().toString(),
-        name,
-        prompt,
-        model,
-        width,
-        height
-      };
-
-      setPresets(prev => [newPreset, ...prev]); // Add new preset to state
-      showToast('Preset saved successfully!', 'success');
-    }
+    setPresetName(''); // Clear previous name
+    setShowSavePresetModal(true);
   };
+
+  // Function to actually save the preset after modal confirmation
+  const handleSavePresetConfirm = () => {
+    if (!presetName.trim()) {
+      showToast('Preset name cannot be empty.', 'error');
+      // Keep modal open, let user correct
+      // inputRef.current?.focus(); // This line caused a build error as inputRef is not in this scope. Modal input focuses on open anyway.
+      return;
+    }
+    if (!prompt.trim()) { // Should not happen if initiateSavePreset was called, but good check
+      showToast('Prompt is empty, cannot save preset.', 'error');
+      setShowSavePresetModal(false);
+      return;
+    }
+
+    const newPreset: Preset = {
+      id: Date.now().toString(),
+      name: presetName.trim(),
+      prompt: prompt.trim(),
+      model,
+      width,
+      height,
+    };
+
+    setPresets(prev => [newPreset, ...prev]);
+    showToast('Preset saved successfully!', 'success');
+    setShowSavePresetModal(false);
+    setPresetName(''); // Clear name for next time
+  };
+
 
   // Function to load a saved preset into the generator
   const loadPreset = (preset: Preset) => {
@@ -689,7 +1192,7 @@ export default function ModernImagen() {
           {/* Conditional Rendering based on Active Tab (Main Content Area) */}
           <main className="mt-8"> {/* Added main tag and margin top */}
           {activeTab === 'generate' && (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:items-start"> {/* Added lg:items-start */}
               
               {/* Image Generation Form */}
               <div className={`rounded-2xl shadow-2xl border p-8 ${
@@ -707,9 +1210,10 @@ export default function ModernImagen() {
                     }`}>
                       Prompt <span className="text-xs">({prompt.length}/1000)</span>
                     </label>
-                    <textarea
-                      id="prompt"
-                      ref={promptTextareaRef} // Assign ref
+                    <div className="relative">
+                      <textarea
+                        id="prompt"
+                        ref={promptTextareaRef} // Assign ref
                       value={prompt}
                       onChange={(e) => setPrompt(e.target.value.slice(0, 1000))}
                       rows={4}
@@ -726,7 +1230,91 @@ export default function ModernImagen() {
                         }
                       }}
                       maxLength={1000}
-                    />
+                      />
+                      <button
+                        id="suggestion-button"
+                        type="button"
+                        onClick={() => setShowSuggestions(!showSuggestions)}
+                        className={`absolute top-2 right-2 p-2 rounded-lg transition-colors ${
+                          theme === 'dark'
+                            ? 'bg-gray-700 hover:bg-gray-600 text-gray-300 hover:text-white'
+                            : 'bg-gray-200 hover:bg-gray-300 text-gray-700 hover:text-gray-900'
+                        }`}
+                        aria-label="Show prompt suggestions"
+                      >
+                        <Lightbulb className="w-4 h-4" />
+                      </button>
+                      {showSuggestions && (
+                        <div
+                          ref={suggestionsRef}
+                          className={`absolute z-10 top-full right-0 mt-1 w-64 max-h-60 overflow-y-auto rounded-md shadow-lg py-1 text-base ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm ${
+                            theme === 'dark' ? 'bg-gray-700 border-gray-600' : 'bg-white border-gray-300'
+                          }`}
+                        >
+                          {predefinedSuggestions.map((suggestion, index) => (
+                            <button
+                              key={index}
+                              onClick={() => handleSuggestionClick(suggestion)}
+                              className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                                theme === 'dark'
+                                  ? 'text-gray-200 hover:bg-gray-600'
+                                  : 'text-gray-700 hover:bg-gray-100'
+                              }`}
+                            >
+                              {suggestion}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Style Presets Section */}
+                  <div className="space-y-3">
+                    <label className={`block text-sm font-medium ${
+                      theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                    }`}>
+                      Style Presets
+                    </label>
+                    <div className="flex items-center space-x-2">
+                      {canScrollStylePresetsLeft && (
+                        <button
+                          onClick={() => scrollStylePresets('left')}
+                          className={`p-2 rounded-full transition-colors ${theme === 'dark' ? 'hover:bg-gray-700' : 'hover:bg-gray-200'}`}
+                          aria-label="Scroll style presets left"
+                        >
+                          <ChevronLeft className={`w-5 h-5 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`} />
+                        </button>
+                      )}
+                      <div ref={stylePresetsContainerRef} className="flex space-x-3 overflow-x-auto pb-2 -mx-1 px-1 hide-native-scrollbar"> {/* Changed to hide-native-scrollbar */}
+                        {stylePresets.map((preset) => (
+                          <button
+                            key={preset.id}
+                          onClick={() => handleStylePresetClick(preset.promptSuffix)}
+                          title={preset.name}
+                          className={`flex-shrink-0 w-24 h-24 sm:w-28 sm:h-28 p-2 rounded-lg border-2 transition-all duration-200 flex flex-col items-center justify-center space-y-1 text-center ${
+                            theme === 'dark'
+                              ? 'bg-gray-700/60 border-gray-600 hover:border-blue-500 hover:bg-gray-700'
+                              : 'bg-gray-100 border-gray-300 hover:border-blue-500 hover:bg-gray-200'
+                          }`}
+                        >
+                          <preset.icon className={`w-8 h-8 sm:w-10 sm:h-10 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`} />
+                          <span className={`text-xs sm:text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
+                            {preset.name}
+                          </span>
+                        </button>
+                      ))}
+                      </div>
+                      {canScrollStylePresetsRight && (
+                        <button
+                          onClick={() => scrollStylePresets('right')}
+                          className={`p-2 rounded-full transition-colors ${theme === 'dark' ? 'hover:bg-gray-700' : 'hover:bg-gray-200'}`}
+                          aria-label="Scroll style presets right"
+                        >
+                          <ChevronRight className={`w-5 h-5 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`} />
+                        </button>
+                      )}
+                    </div>
                   </div>
 
                   {/* Width and Height Inputs - Stacked on mobile, side-by-side on md+ */}
@@ -792,6 +1380,28 @@ export default function ModernImagen() {
                     </select>
                   </div>
 
+                  {/* Batch Size Input */}
+                  <div className="space-y-1">
+                    <label htmlFor="batchSize" className={`block text-sm font-medium mb-1 ${
+                        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                      }`}>
+                        Number of Images (1-5)
+                      </label>
+                      <input
+                        id="batchSize"
+                        type="number"
+                        value={batchSize}
+                        onChange={(e) => setBatchSize(Number(e.target.value))}
+                        min="1"
+                        max="5"
+                        className={`w-full rounded-lg p-3 border focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 min-h-[44px] ${
+                          theme === 'dark'
+                            ? 'bg-gray-900 border-gray-600 text-white'
+                            : 'bg-gray-50 border-gray-300 text-gray-900'
+                        }`}
+                      />
+                  </div>
+
                   {/* Seed Input with Random Button */}
                   <div className="space-y-1">
                     <label htmlFor="seed" className={`block text-sm font-medium mb-1 ${
@@ -845,7 +1455,7 @@ export default function ModernImagen() {
                       )}
                     </button>
                     <button
-                      onClick={savePreset}
+                      onClick={initiateSavePreset}
                       className={`flex-1 sm:flex-none px-4 sm:px-6 py-3 rounded-lg transition-colors min-h-[44px] flex items-center justify-center ${
                         theme === 'dark'
                           ? 'bg-green-700 hover:bg-green-600 text-white'
@@ -900,14 +1510,65 @@ export default function ModernImagen() {
             </div>
           )}
 
+          {/* Display area for current batch results on Generate Tab */}
+          {activeTab === 'generate' && currentBatchResults.length > 0 && (
+            <div className={`mt-10 pt-6 ${theme === 'dark' ? 'border-gray-700' : 'border-gray-200'} border-t`}>
+              <h3 className={`text-lg font-semibold mb-4 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
+                Last Batch Results ({currentBatchResults.length})
+              </h3>
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                {currentBatchResults.map((image) => (
+                  <div
+                    key={`batch-${image.id}`}
+                    className={`group relative rounded-lg overflow-hidden border cursor-pointer transition-all duration-300 focus-within:ring-2 focus-within:ring-blue-500 ${
+                      theme === 'dark' ? 'bg-gray-800/70 border-gray-700 hover:border-gray-600' : 'bg-white border-gray-200 hover:border-gray-300 shadow-sm'
+                    }`}
+                    onClick={() => enlargeImage(image.url, image.prompt)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') enlargeImage(image.url, image.prompt);}}
+                    aria-label={`View enlarged image for prompt: ${image.prompt}`}
+                  >
+                    <img
+                      src={image.url}
+                      alt={image.prompt}
+                      className="w-full h-full object-cover aspect-square group-hover:scale-105 transition-transform"
+                      loading="lazy"
+                    />
+                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors" />
+                     {/* Minimal info overlay */}
+                    <div className="absolute bottom-0 left-0 right-0 p-1.5 bg-gradient-to-t from-black/70 to-transparent">
+                      <p className="text-white text-xs truncate">{image.prompt}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* History Tab Content */}
           {activeTab === 'history' && (
             <div className="space-y-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                 <h2 className="text-xl sm:text-2xl font-bold">Generation History</h2>
-                <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
-                  {images.length} image{images.length === 1 ? '' : 's'}
-                </span>
+                <div className="flex items-center space-x-4">
+                  {selectedForComparison.length >= 2 && (
+                    <button
+                      onClick={() => setShowComparisonView(true)}
+                      className={`px-4 py-2 rounded-lg transition-colors min-h-[44px] flex items-center justify-center text-sm font-medium shadow-sm ${
+                        theme === 'dark'
+                          ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                          : 'bg-blue-500 hover:bg-blue-600 text-white'
+                      }`}
+                    >
+                      Compare Selected ({selectedForComparison.length})
+                    </button>
+                  )}
+                  <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {images.length} image{images.length === 1 ? '' : 's'}
+                    {selectedForComparison.length > 0 && ` (${selectedForComparison.length} selected)`}
+                  </span>
+                </div>
               </div>
               {images.length === 0 ? (
                 <div className={`text-center py-10 sm:py-12 rounded-xl ${
@@ -930,7 +1591,9 @@ export default function ModernImagen() {
                       onCopy={copyToGenerate}
                       onDownload={downloadImage}
                       onEnlarge={(img) => enlargeImage(img.url, img.prompt)}
-                      theme={theme} // Pass theme
+                      theme={theme}
+                      isSelected={selectedForComparison.includes(image.id)}
+                      onSelect={toggleSelectForComparison}
                     />
                   ))}
                 </div>
@@ -990,6 +1653,32 @@ export default function ModernImagen() {
           theme={theme}
         />
       )}
+
+      {showComparisonView && selectedForComparison.length >= 2 && (
+        <ComparisonModal
+          imagesToCompare={selectedForComparison}
+          allImages={images}
+          theme={theme}
+          onClose={() => {
+            setShowComparisonView(false);
+            // Optionally, clear selection after closing:
+            // setSelectedForComparison([]);
+          }}
+          onDownload={downloadImage}
+        />
+      )}
+
+      <SavePresetModal
+        isOpen={showSavePresetModal}
+        onClose={() => {
+          setShowSavePresetModal(false);
+          setPresetName(''); // Clear name on close
+        }}
+        onSave={handleSavePresetConfirm}
+        presetName={presetName}
+        setPresetName={setPresetName}
+        theme={theme}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This commit introduces two key User Experience improvements:

1.  **Dynamic Image Card Height:**
    *   Modified the layout of the "Generate" tab so that the image display card (right column on large screens) now dynamically adjusts its height based on its content (the displayed image).
    *   It no longer stretches to match the height of the image generation form card (left column), providing a more balanced and content-aware layout. This was achieved by setting `lg:items-start` on the parent grid container.

2.  **Main Page Batch Image Display:**
    *   When multiple images are generated in a batch, they are now displayed directly on the "Generate" tab in a new section titled "Last Batch Results."
    *   This section appears below the main image preview area and shows a grid of the generated batch images.
    *   Users no longer need to switch to the "History" tab to see their batch outputs immediately.
    *   The main preview area will show the first image from a successful batch.
    *   The `currentBatchResults` state manages the display of these images, and it's cleared when a new generation process (single or batch) begins.
    *   Each image in the batch display is clickable to open in an enlarged view (modal).
    *   Seed generation for batches now ensures all images in a batch use random seeds if batch size > 1, for maximum variation.